### PR TITLE
Add cleanup helper for scene groups

### DIFF
--- a/3d-animated-blockchain.html
+++ b/3d-animated-blockchain.html
@@ -549,12 +549,31 @@ function makeCube(defaultColor, isTrailSegment = false, trailOpacity = 1.0) {
   return group;
 }
 
+// ========= Cleanup Helper =========
+function disposeGroup(group) {
+  if (!group) return;
+  group.traverse(obj => {
+    if (obj.geometry) obj.geometry.dispose();
+    if (obj.material) {
+      if (Array.isArray(obj.material)) {
+        obj.material.forEach(m => m.dispose());
+      } else {
+        obj.material.dispose();
+      }
+    }
+    if (obj.isLight && typeof obj.dispose === 'function') {
+      obj.dispose();
+    }
+  });
+  group.clear();
+}
+
 // ========= Build Graph =========
 function rebuild() {
   // Clear all groups first to ensure a fresh rebuild
-  graphGroup.clear();
-  pulsesGroup.clear();
-  pulseTrailsGroup.clear();
+  disposeGroup(graphGroup);
+  disposeGroup(pulsesGroup);
+  disposeGroup(pulseTrailsGroup);
   
   // Ensure all groups are visible
   graphGroup.visible = true;
@@ -646,8 +665,8 @@ function buildGraph() {
 
 // ========= Pulses & Trails =========
 function rebuildPulses() {
-  pulsesGroup.clear(); 
-  pulseTrailsGroup.clear(); // Clear old trails
+  disposeGroup(pulsesGroup);
+  disposeGroup(pulseTrailsGroup); // Clear old trails
   pulses = [];
   if (!edges.length || params.pulseCount === 0) return;
   for (let i = 0; i < params.pulseCount; i++) {


### PR DESCRIPTION
## Summary
- add `disposeGroup` helper to traverse groups and dispose child assets
- use helper when clearing groups in `rebuild` and `rebuildPulses`

## Testing
- `git log -1 --stat`